### PR TITLE
Added 'sanitze' option to allow serving responses 'as is'

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ file with no query params if it exists.
 
 *Warning this will be deprecated in the future since canned now supports
 multiple response based on the request body or GET URL parameters in one file.
-This is the prefered way since files with ? in the name do not work on Windows*
+This is the preferred way since files with ? in the name do not work on Windows*
 
     file                            | resquest
     /index?name=Superman.get.json   | GET /?name=Superman&NotAllParams=NeedToMatch
@@ -293,7 +293,7 @@ these can be added like this (thanks to runemadsen)
 
     $ canned --headers "Authorization, Another-Header"
 
-To enable CORS programatically, you can use the following options:
+To enable CORS programmatically, you can use the following options:
 
     var canned = require('canned')
     ,   http = require('http')
@@ -303,6 +303,15 @@ To enable CORS programatically, you can use the following options:
         }
 
 Optionally, the cors_headers value can be a comma-separated string, as per the CLI option.
+
+Other optional options include:
+    
+    var opts = {
+            sanitize: false, // get responses as is without any sanitization
+            response_delay: 2000, // delay the response for 2 seconds
+            relaxed_accept: true // iterate through all accepted content types in the `Accept` header
+            wildcard: 'myany', // specify 'wildcard' directory, e.g. ./canned/api/users/myany/index.get.json
+        }
 
 For more information checkout [the pull request](https://github.com/sideshowcoder/canned/pull/9)
 
@@ -382,13 +391,13 @@ Release History
 
 ### 0.3.5
 * support for custom HTTP headers in responses
-* fix for matching multiple paramters in response #73 thanks
+* fix for matching multiple parameters in response #73 thanks
   [xdemocle](https://github.com/xdemocle)
 * fix any wildcard in the middle of the path #66 thanks
   [msurdi](https://github.com/msurdi)
 
 ### 0.3.4
-* update depedencies and dev-dependencies
+* update dependencies and dev-dependencies
 * wildcard parameters thanks to [msurdi](https://github.com/msurdi) see
   https://github.com/sideshowcoder/canned/pull/64
 

--- a/lib/canned.js
+++ b/lib/canned.js
@@ -13,7 +13,7 @@ function Canned(dir, options) {
   this.logger = options.logger
   this.wildcard = options.wildcard || 'any'
   this.relaxed_accept = options.relaxed_accept
-  this.sanitize = options.sanitize || true
+  this.sanitize = options.sanitize !== undefined ? options.sanitize : true
   var cors_headers = options.cors_headers
   if (cors_headers && cors_headers.join) {
     cors_headers = cors_headers.join(', ')

--- a/lib/canned.js
+++ b/lib/canned.js
@@ -5,7 +5,6 @@ var fs = require('fs')
 var util = require('util')
 var Response = require('./response')
 var querystring = require('querystring')
-var url = require('url')
 var cannedUtils = require('./utils')
 var lookup = require('./lookup')
 var _ = require('lodash')
@@ -14,6 +13,7 @@ function Canned(dir, options) {
   this.logger = options.logger
   this.wildcard = options.wildcard || 'any'
   this.relaxed_accept = options.relaxed_accept
+  this.sanitize = options.sanitize || true
   var cors_headers = options.cors_headers
   if (cors_headers && cors_headers.join) {
     cors_headers = cors_headers.join(', ')
@@ -59,7 +59,7 @@ Canned.prototype._getFileFromRequest = function(httpObj, files) {
 
   if (!files) return false
 
-  var m, i, e, matchString, matchPattern, fileMatch, ctype
+  var m, i, e, matchString, fileMatch, ctype
 
   // if query params, match regexp based on fname to request
   if(httpObj.query)
@@ -221,7 +221,7 @@ Canned.prototype.getVariableResponse = function(data, content, headers) {
 Canned.prototype.sanatizeContent = function (data, fileObject) {
   var sanatized
 
-  if (data.length === 0) {
+  if (data.length === 0 || !this.sanitize) {
     return data
   }
 

--- a/lib/canned.js
+++ b/lib/canned.js
@@ -203,7 +203,9 @@ Canned.prototype.getSelectedResponse = function(responses, content, headers) {
 
 // return multiple response bodies as array
 Canned.prototype.getEachResponse = function(data) {
-  data = cannedUtils.removeJSLikeComments(data)
+  if (this.sanitize) {
+    data = cannedUtils.removeJSLikeComments(data)
+  }
   var responses = data.split(/\n\n(?=[\/\/!])/).filter(function (e) { return e !== '' })
   return responses
 }

--- a/spec/canned.spec.js
+++ b/spec/canned.spec.js
@@ -56,13 +56,13 @@ describe('canned', function () {
 
   describe('sanitization', function () {
     var writeLog, logCan
+    var logger = {
+      write: function (msg) {
+        if (writeLog) writeLog(msg)
+      }
+    }
     describe('with sanitization enabled', function() {
       beforeEach(function () {
-        var logger = {
-          write: function (msg) {
-            if (writeLog) writeLog(msg)
-          }
-        }
         logCan = canned('./spec/test_responses', { logger: logger })
       })
 
@@ -81,11 +81,6 @@ describe('canned', function () {
 
     describe('with sanitization disabled', function() {
       beforeEach(function () {
-        var logger = {
-          write: function (msg) {
-            if (writeLog) writeLog(msg)
-          }
-        }
         logCan = canned('./spec/test_responses', { logger: logger, sanitize: false })
       })
 

--- a/spec/test_responses/_broken_sanitize.get.json
+++ b/spec/test_responses/_broken_sanitize.get.json
@@ -1,0 +1,5 @@
+{
+  "whatAmI": "I have been copy/pasted into a WYSIWYG editor by your grandma",
+  "embedCode": "<div class=\"nasty-3rd-party-code\">\n\n\n<script type=\"text/javascript\">\nvar someValue = 'I will make you cry';\n// --></script>\n</script>  </p>\n\nHuh?<p>\n\n</div>\n\nYes, true story!",
+  "honestly": "Can we get an Internet User Licence introduced already?"
+}


### PR DESCRIPTION
Canned uses a "sanitize" regex to ensure that JSON is valid before sending it over the wire. 

Unfortunately, content with unusual or invalid markup as part of the JSON values, triggers this regex. 

This PR introduces a flag which can be set to turn off the default sanitization of JSON content, thus passing the content on 'as is'. Any consumer is left to deal with the fallout, rather that it breaking at the canned level.